### PR TITLE
Add MetaProvides::Package to list of loaded plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This bundle provides the following plugins and bundles:
       [GitHub::Meta]
       [InstallGuide]
       [MetaJSON]
+      [MetaProvides::Package]
       [MinimumPerl]
       [NextRelease]
       [ReadmeFromPod]

--- a/lib/Dist/Zilla/PluginBundle/IDOPEREL.pm
+++ b/lib/Dist/Zilla/PluginBundle/IDOPEREL.pm
@@ -17,6 +17,7 @@ use Dist::Zilla::PluginBundle::Basic;
 use Dist::Zilla::PluginBundle::Git;
 use Dist::Zilla::Plugin::VersionFromModule;
 use Dist::Zilla::Plugin::MetaJSON;
+use Dist::Zilla::Plugin::MetaProvides::Package;
 use Dist::Zilla::Plugin::MinimumPerl;
 use Dist::Zilla::Plugin::AutoPrereqs;
 use Dist::Zilla::Plugin::Prereqs;
@@ -62,6 +63,7 @@ This bundle provides the following plugins and bundles:
       [GitHub::Meta]
       [InstallGuide]
       [MetaJSON]
+      [MetaProvides::Package]
       [MinimumPerl]
       [NextRelease]
       [ReadmeFromPod]
@@ -109,6 +111,7 @@ sub configure {
 		'GitHub::Meta',
 		'InstallGuide',
 		'MetaJSON',
+		'MetaProvides::Package',
 		'MinimumPerl',
 		'NextRelease',
 		'TestRelease',


### PR DESCRIPTION
This fixes some meta issues as reported by CPANTS. In particular [`meta_yml_has_provides`](https://cpants.cpanauthors.org/kwalitee/meta_yml_has_provides), affecting at least [Plack::App::MCCS](https://cpants.cpanauthors.org/dist/Plack-App-MCCS).

This is part of the (belated) Pull Request Challenge for that distribution.